### PR TITLE
Update Wechat-api module

### DIFF
--- a/broid-wechat/package.json
+++ b/broid-wechat/package.json
@@ -78,7 +78,7 @@
     "rxjs": "^5.0.2",
     "tmp": "^0.0.31",
     "uuid": "^3.1.0",
-    "wechat-api": "git+https://git@github.com/node-webot/wechat-api.git#295ad45e199ef93610c4d3a9350de6992a932d8c"
+    "wechat-api": "^1.35.0"
   },
   "ava": {
     "files": [


### PR DESCRIPTION
Fixing issue where Broid wechat would throw the following error when receiving a message over the wechat api.

`Cannot read property '0' of undefined`

Updating the wechat api module fixes the suspect message parse issues. Several months of development have occurred since the version committed to the package.json